### PR TITLE
C30-I2-adjusting the functionality of opened sidebar at window width

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 useful-links.md
 commands.md
+outdated_code.md
 
 # Django #
 *.log

--- a/static-files/js/sidebar.js
+++ b/static-files/js/sidebar.js
@@ -9,6 +9,16 @@ openHamburgerMenu.onclick = () => {
    sidebar.style.display = 'block';
 };
 
+function closeSidebar() {
+   var w = window.innerWidth;
+   if (w > 768) {
+      sidebar.style.display = 'none';
+      background.style.display = 'none';
+   }
+}
+
+window.addEventListener("resize", closeSidebar);
+
 closeHamburgerMenu.onclick = () => {
    sidebar.style.display = 'none';
    background.style.display = 'none';


### PR DESCRIPTION
This commit has a code which allows to close/disable opened sidebar when the width of a page window goes above 768px which is 'md' for tailwindcss.

'md' => medium view. This is a functionality in tailwind and it has an equal purpose to media queries used in CSS language.
