### PR TITLE
C12-I16-overflow of the data vis container content

### DIFF
--- a/templates/neurons/data_visualisations_container.html
+++ b/templates/neurons/data_visualisations_container.html
@@ -14,20 +14,20 @@
 <body>
   
   <!-- Main container -->
-  <div class="mb-14 lg:flex lg:gap-5">
+  <div class="mb-14 flex gap-5 justify-between overflow-x-auto">
 
     <!-- Control Panel -->
-    <div class="bg-zinc-100 rounded-md shadow-xl w-5/6 h-2/4 mx-auto lg:rounded-l-none lg:w-1/3 xl:w-1/5">
-      <div class="py-6 px-5">
+    <div class="bg-zinc-100 rounded-md shadow-xl h-2/4 ml-0 rounded-l-none">
+      <div class="py-6 px-5 w-80">
         <div class="mb-6">
-          <h2 class="text-3xl font-medium lg:text-4xl">View (all)</h2>
+          <h2 class="font-medium text-4xl">View (all)</h2>
         </div>
         <div class="flex justify-between mb-8">
           <label for="neuron-checkbox" class="text-lg">Neurons</label>
           <input type="checkbox" id="neuron-checkbox" name="neuron-checkbox" checked class="px-3 py-3 rounded-md">
         </div>
         <div class="mb-6">
-          <h2 class="text-3xl font-medium lg:text-4xl lg:mb-4">Sort by</h2>
+          <h2 class="font-medium text-4xl mb-4">Sort by</h2>
         </div>
         <div class="border border-zinc-400 rounded-t-md">
           <div class="flex justify-between bg-zinc-200 py-2 px-2 rounded-t-md">
@@ -63,10 +63,10 @@
       </div>
     </div>
 
-      <!-- Visualisation container w=610 h=700 -->
-      <div class="w-5/6 mx-auto mt-5 lg:mt-0">
-        <div id="data-vis-wrapper" class="bg-zinc-100 py-5 rounded-md shadow-xl lg:mt-0 lg:rounded-r-none">
-          <svg id="data-vis-container" width="600" height="700" class="rounded-md border border-zinc-300"></svg>
+      <!-- Visualisation container -->
+      <div class="mr-0 mt-0">
+        <div id="data-vis-wrapper" class="bg-zinc-100 p-5 rounded-md shadow-xl mt-0 rounded-r-none">
+          <svg id="data-vis-container" width="1500" height="700" class="rounded-md border border-zinc-300"></svg>
         </div>
 
         <!-- Data Visualisations Legend -->

--- a/templates/neurons/data_visualisations_container_legend.html
+++ b/templates/neurons/data_visualisations_container_legend.html
@@ -21,7 +21,7 @@
           <span class="italic text-sm">* split by their type</span>
         </div>
 
-        <div class="grid grid-cols-2 space-y-1 md:grid-cols-4">
+        <div class="grid space-y-1 grid-cols-4">
           <!-- Pharynx -->
           <div class="flex gap-2 mx-auto">
             <!-- Circle -->

--- a/templates/neurons/visualisations_page.html
+++ b/templates/neurons/visualisations_page.html
@@ -19,7 +19,7 @@
   <main class="block mx-auto w-11/12 xl:w-10/12">
     <!-- Page title -->
     <div class="my-14">
-      <h1 class="text-4xl font-medium lg:text-5xl xl:text-6xl">C. elegans Data Visualisations</h1>
+      <h1 class="font-medium text-6xl">C. elegans Data Visualisations</h1>
     </div>
   </main>
 


### PR DESCRIPTION
- full overflow of the content of the Visualisations page, remaining in a shape always as if it was in a full width view
- navbar and footer do not overflow